### PR TITLE
fix sitemap.sh when markdown title in chinese

### DIFF
--- a/docs/sitemap.sh
+++ b/docs/sitemap.sh
@@ -28,7 +28,7 @@ items=""
 for file in ${files[@]}; do
   [[ ${ignore[@]/${file}/} != ${ignore[@]} ]] && continue
   echo $file
-  encode=$(urlencode "${file::-3}")
+  encode=$(urlencode "${file%.*}")
   link="$website_link/#/$encode"
   date=$(git log -1 --format="%ad" --date="iso-strict-local" -- $file)
   item="


### PR DESCRIPTION
修复markdown中文标题执行异常：

ERROR:
    ./sitemap.sh: line 34: -3: substring expression < 0
    
    
感谢提供sitemap生成工具！！